### PR TITLE
Add configuration class for application settings using Pydantic

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,0 +1,17 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+import os
+
+class Config(BaseSettings):
+    app_name: str
+    host: str
+    port: int
+    database_host: str
+    database_port: int
+    database_name: str
+    database_user: str
+    database_password: str
+    token_secret_key: str
+    token_algorithm: str
+    token_expiration_in_minutes: int
+
+    model_config = SettingsConfigDict(env_file=f"{os.getcwd()}/.env.dev")


### PR DESCRIPTION
This pull request includes a significant addition to the `src/utils/config.py` file, introducing a new configuration class using the `pydantic_settings` library. The most important change is the creation of the `Config` class, which centralizes various application settings and reads them from an environment file.

Configuration management improvements:

* [`src/utils/config.py`](diffhunk://#diff-fd70cddefcee959f5230b7b8f1a476286c434ec4110a3065044a75354610b483R1-R17): Added the `Config` class that inherits from `BaseSettings` and includes various application settings such as `app_name`, `host`, `port`, and database credentials. The settings are loaded from an `.env.dev` file using the `SettingsConfigDict` model configuration.