### PR TITLE
Add JWTBearerDependencie for JWT authentication handling

### DIFF
--- a/src/utils/dependencies.py
+++ b/src/utils/dependencies.py
@@ -1,0 +1,39 @@
+from fastapi import Request, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+from src.schemas.responses import ValidationErrorResponse
+from src.utils.token import JWTManager
+
+
+class JWTBearerDependencie(HTTPBearer):
+    """
+    JWTBearerDependencie is a custom dependency class that extends HTTPBearer for handling JWT authentication.
+    Methods:
+    --------
+    __init__(self, auto_error: bool = True):
+        Initializes the JWTBearerDependencie with an optional auto_error parameter.
+    __call__(self, req: Request):
+        Asynchronously processes the incoming request to extract and decode the JWT token.
+        Raises an HTTPException with status code 401 if the token is invalid or decoding fails.
+    Parameters:
+    -----------
+    auto_error : bool, optional
+        If set to True, automatically raises an HTTPException for authentication errors (default is True).
+    Returns:
+    --------
+    decoded_token : dict
+        The decoded JWT token if authentication is successful.
+    """
+
+    def __init__(self, auto_error: bool = True):
+        super(JWTBearerDependencie, self).__init__(auto_error=auto_error)
+
+    async def __call__(self, req: Request):
+        credentials: HTTPAuthorizationCredentials = await super(JWTBearerDependencie, self).__call__(req)
+        
+        try:
+            decoded_token = JWTManager().decode(credentials.credentials)
+        except ValueError as error:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail={'error': error.__str__()})
+    
+        return decoded_token


### PR DESCRIPTION
This pull request introduces a new custom dependency class for handling JWT authentication in the `src/utils/dependencies.py` file. The most important changes include the addition of necessary imports and the implementation of the `JWTBearerDependencie` class.

### JWT Authentication:

* [`src/utils/dependencies.py`](diffhunk://#diff-40d678bffd1c01cc1460f00fc7e45d18123383a703e744e262349928c3caa912R1-R39): Added necessary imports for handling JWT authentication, including `Request`, `HTTPException`, `status`, `HTTPBearer`, `HTTPAuthorizationCredentials`, `ValidationErrorResponse`, and `JWTManager`.
* [`src/utils/dependencies.py`](diffhunk://#diff-40d678bffd1c01cc1460f00fc7e45d18123383a703e744e262349928c3caa912R1-R39): Implemented the `JWTBearerDependencie` class, which extends `HTTPBearer` to handle JWT authentication by decoding tokens and raising exceptions for invalid tokens.