### PR TITLE
Add CloudFormation template for publicly accessible RDS MySQL instance

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -1,0 +1,47 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: "CloudFormation template to create a publicly accessible RDS MySQL instance"
+
+Resources:
+  MyDBSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "Allow MySQL access"
+      VpcId: vpc-0f06869a5fbbe6689
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 3306
+          ToPort: 3306
+          CidrIp: 0.0.0.0/0 
+
+  DBSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties:
+      DBSubnetGroupDescription: "Subnet group for RDS"
+      SubnetIds:
+        - subnet-0ec3f7abf2eed48cd 
+        - subnet-08dcf7eae3193c496
+        - subnet-0c10be8aa9138757e
+
+
+  CustomersDBInstance:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      DBInstanceIdentifier: customersdatabase-mysql
+      AllocatedStorage: 20
+      DBInstanceClass: db.t3.micro
+      Engine: mysql
+      EngineVersion: "8.0"
+      MasterUsername: admin
+      MasterUserPassword: Xcvi762gsnoanAswrabzn 
+      DBName: customers
+      VPCSecurityGroups:
+        - !Ref MyDBSecurityGroup
+      BackupRetentionPeriod: 7
+      MultiAZ: false
+      PubliclyAccessible: true 
+      DBSubnetGroupName: !Ref DBSubnetGroup
+
+Outputs:
+  RDSInstanceEndpoint:
+    Description: "The endpoint of the publicly accessible RDS instance"
+    Value: !GetAtt CustomersDBInstance.Endpoint.Address


### PR DESCRIPTION
This pull request adds a new CloudFormation template to create a publicly accessible RDS MySQL instance. The most important changes include defining resources for the security group, subnet group, and the RDS instance itself.

CloudFormation Template Additions:

* `cloudformation.yml`: Added a new CloudFormation template with the following resources:
  * [`MyDBSecurityGroup`](diffhunk://#diff-516cd3f72f255daf0e24ed512c77e35757c2020dd4ef9425985f0861007fef68R1-R47): Security group allowing MySQL access on port 3306 from any IP address.
  * [`DBSubnetGroup`](diffhunk://#diff-516cd3f72f255daf0e24ed512c77e35757c2020dd4ef9425985f0861007fef68R1-R47): Subnet group for the RDS instance, including three subnets.
  * [`CustomersDBInstance`](diffhunk://#diff-516cd3f72f255daf0e24ed512c77e35757c2020dd4ef9425985f0861007fef68R1-R47): RDS MySQL instance with specific configurations such as instance class, engine version, master username and password, and public accessibility.
  * Outputs section to provide the endpoint address of the RDS instance.